### PR TITLE
Add log path selection and save toggle

### DIFF
--- a/genarater.py
+++ b/genarater.py
@@ -66,14 +66,21 @@ def main() -> None:
     include_special = ask_yes_no("Include special characters")
     capitalize_first = ask_yes_no("Capitalize first letter")
     copy_clipboard = ask_yes_no("Copy password to clipboard")
+    save_file = ask_yes_no("Save password to log file")
+    log_dir = "data_file"
+    if save_file:
+        custom = input("Log directory path (default data_file): ").strip()
+        if custom:
+            log_dir = custom
     note = input("Note for this password: ")
 
     alphabet = build_alphabet(include_letters, include_digits, include_special)
     password = generate_password(length, alphabet, capitalize_first)
 
-    os.makedirs("data_file", exist_ok=True)
-    with open("data_file/Token.txt", "a", encoding="utf-8") as f:
-        f.write(f"{note}: {password}\n")
+    if save_file:
+        os.makedirs(log_dir, exist_ok=True)
+        with open(os.path.join(log_dir, "Token.txt"), "a", encoding="utf-8") as f:
+            f.write(f"{note}: {password}\n")
 
     if copy_clipboard:
         if pyperclip:

--- a/gui.py
+++ b/gui.py
@@ -5,7 +5,7 @@ import os
 import secrets
 import string
 import tkinter as tk
-from tkinter import messagebox
+from tkinter import filedialog, messagebox
 from tkinter import ttk
 
 try:
@@ -20,7 +20,8 @@ def copy_password() -> None:
         return
     if pyperclip:
         pyperclip.copy(password)
-        messagebox.showinfo("已复制", "密码已复制到剪贴板")
+        status_var.set("密码已复制到剪贴板")
+        root.after(2000, lambda: status_var.set(""))
     else:
         messagebox.showwarning("Unavailable", "pyperclip not installed.")
 
@@ -54,9 +55,10 @@ def generate_password() -> None:
         password = ''.join(secrets.choice(alphabet) for _ in range(length))
 
     note = note_var.get()
-    os.makedirs("data_file", exist_ok=True)
-    with open("data_file/Token.txt", "a", encoding="utf-8") as f:
-        f.write(f"{note}: {password}\n")
+    if save_var.get():
+        os.makedirs(log_path_var.get(), exist_ok=True)
+        with open(os.path.join(log_path_var.get(), "Token.txt"), "a", encoding="utf-8") as f:
+            f.write(f"{note}: {password}\n")
 
     result_var.set(password)
 
@@ -94,8 +96,11 @@ digits_var = tk.BooleanVar(value=True)
 special_var = tk.BooleanVar(value=False)
 capital_var = tk.BooleanVar(value=False)
 copy_var = tk.BooleanVar(value=False)
+save_var = tk.BooleanVar(value=True)
+log_path_var = tk.StringVar(value="data_file")
 note_var = tk.StringVar()
 result_var = tk.StringVar()
+status_var = tk.StringVar()
 
 main_frame = ttk.Frame(root, padding=20)
 main_frame.pack(fill="both", expand=True)
@@ -140,15 +145,28 @@ capital_cb = ttk.Checkbutton(frame, text="首字母大写", variable=capital_var
 capital_cb.grid(row=2, column=1, sticky="w")
 copy_cb = ttk.Checkbutton(frame, text="生成后自动复制", variable=copy_var)
 copy_cb.grid(row=3, column=0, columnspan=2, sticky="w")
+save_cb = ttk.Checkbutton(frame, text="保存到日志", variable=save_var)
+save_cb.grid(row=3, column=2, sticky="w")
 
 note_label = ttk.Label(frame, text="备注:")
 note_label.grid(row=4, column=0, sticky="e")
 note_entry = ttk.Entry(frame, textvariable=note_var, width=30)
 note_entry.grid(row=4, column=1, sticky="w")
-ttk.Label(frame, text="会记录在日志中").grid(row=4, column=2, sticky="w", padx=(5,0))
+ttk.Label(frame, text="用于日志记录").grid(row=4, column=2, sticky="w", padx=(5,0))
+
+path_label = ttk.Label(frame, text="日志目录")
+path_label.grid(row=5, column=0, sticky="e")
+path_entry = ttk.Entry(frame, textvariable=log_path_var, width=25)
+path_entry.grid(row=5, column=1, sticky="w")
+def choose_dir():
+    path = filedialog.askdirectory(initialdir=log_path_var.get() or '.')
+    if path:
+        log_path_var.set(path)
+choose_btn = ttk.Button(frame, text="选择...", command=choose_dir)
+choose_btn.grid(row=5, column=2, sticky="w")
 
 generate_button = ttk.Button(frame, text="生成密码", command=generate_password)
-generate_button.grid(row=5, column=0, columnspan=3, pady=(5, 0))
+generate_button.grid(row=6, column=0, columnspan=3, pady=(5, 0))
 
 result_frame = ttk.Frame(main_frame, padding=(0,10,0,0))
 result_frame.pack(fill="x")
@@ -156,6 +174,8 @@ result_entry = ttk.Entry(result_frame, textvariable=result_var, state="readonly"
 result_entry.pack(side="left", fill="x", expand=True)
 copy_btn = ttk.Button(result_frame, text="复制", command=copy_password)
 copy_btn.pack(side="left", padx=(5,0))
+status_label = ttk.Label(main_frame, textvariable=status_var)
+status_label.pack(fill="x")
 
 # 监听字母复选框变化，控制首字母大写可用性
 def on_letters_var_change(*args):


### PR DESCRIPTION
## Summary
- show copy status in GUI instead of dialog
- allow choosing log directory in GUI
- add option to toggle saving passwords in GUI and CLI

## Testing
- `python -m py_compile genarater.py gui.py`


------
https://chatgpt.com/codex/tasks/task_e_6845b2ba3364832c8e3cb0e56bf87059